### PR TITLE
OpenGL環境で正常に描画されない問題の解決

### DIFF
--- a/Assets/Shaders/Raymarching.cginc
+++ b/Assets/Shaders/Raymarching.cginc
@@ -43,10 +43,10 @@ float3 compute_ray_dir(float4 screen)
 //depthの算出方法はDirect3DとOpenGL系で違う。
 float compute_depth(float4 pos)
 {
-#if defined(SHADER_TARGET_GLSL)
-	return (pos.z / pos.w) * 0.5 + 0.5;
+#if UNITY_UV_STARTS_AT_TOP
+    return pos.z / pos.w;
 #else
-	return pos.z / pos.w;
+    return (pos.z / pos.w) * 0.5 + 0.5;   
 #endif
 }
 

--- a/Assets/Shaders/Raymarching.shader
+++ b/Assets/Shaders/Raymarching.shader
@@ -9,6 +9,7 @@
 		Pass
 		{
 			Tags { "LightMode" = "Deferred" }
+			Cull Off
 			//G-Bufferへの描画はStencil を有効にして7bit目を立てる(128を足す)。
 			//Stencilの7bit目が立っていないピクセルはライティングされない。
 			//なので常にステンシルテストに合格させ、128で上書きする。


### PR DESCRIPTION
## 概要

OpenGL環境でRaymarchingによる描画がされない問題の修正
## 詳細

OpenGLではカリングを無効にしないと描画されなかった。

また、Depthの出力方法がDirect3DとOpenGL系で異なるが

> #if defined(SHADER_TARGET_GLSL)

という文言がOpenGL系であるという判定には使えなかった(少なくともUnityエディタ上では)そのため

> # if UNITY_UV_STARTS_AT_TOP

を用いるように変更した。
これはDirect3Dでは1、 OpenGL系では0を返してくれるので、DirectX環境でもうまく動いてくれると思う。
要確認。
